### PR TITLE
base64_decode tidak menutup hasil string password dengan special character di akhir string

### DIFF
--- a/admina/inc/feeder_function.php
+++ b/admina/inc/feeder_function.php
@@ -103,6 +103,10 @@ function convert_ascii($string)
   function dec_data($data) {
   $replace_encode = substr_replace($data, '', 3 , 3);
   $decode = base64_decode($replace_encode);
+  // Bug saat password feeder terdapat special character di akhir string sehingga menyebabkan base64_decode tidak menutup string.
+  if(substr($decode, -1) !== '"') {
+    $decode = $decode.'"';
+  }
   $json_sys = json_decode($decode);
   return $json_sys;
 }


### PR DESCRIPTION
if(substr($decode, -1) !== '"') {
    $decode = $decode.'"';
  }

penambahan hasil decode yang tidak menutup string dari password saat terdapat special character pada akhir string